### PR TITLE
scalajs and locales tests

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
-import org.scalajs.sbtplugin.cross.CrossProject
+import org.scalajs.sbtplugin.ScalaJSJUnitPlugin
+import sbt._
 
 parallelExecution in ThisBuild := false
 
@@ -27,13 +28,23 @@ lazy val threetenbpRoot = project.in(file("."))
     crossScalaVersions := crossScalaVer
   )
 
-
 lazy val threetenbpCross = crossProject.crossType(CrossType.Full).in(file("."))
+  .jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin))
+  .settings(commonSettings: _*)
   .settings(
+    testOptions +=
+      Tests.Argument(TestFramework("com.novocode.junit.JUnitFramework"), "-v", "-a")
+  ).jvmSettings(
     libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % "3.0.0-RC4" % "test",
-      "junit" % "junit" % "4.12" % "test",
-      "org.testng" % "testng" % "6.9.10" % "test"
+      "org.scalatest" %%% "scalatest" % "3.0.0-M15" % "test",
+      "org.testng" % "testng" % "6.9.10" % "test",
+      "com.novocode" % "junit-interface" % "0.9" % "test"
+    )
+  ).jsSettings(
+    testOptions +=
+      Tests.Argument(TestFramework("com.novocode.junit.JUnitFramework"), "-v", "-a"),
+    libraryDependencies ++= Seq(
+      "com.github.cquiroz" %%% "scala-java-locales" % "0.1.0+29"
     )
   )
 

--- a/shared/src/main/scala/org/threeten/bp/format/DecimalStyle.scala
+++ b/shared/src/main/scala/org/threeten/bp/format/DecimalStyle.scala
@@ -32,9 +32,11 @@
 package org.threeten.bp.format
 
 import java.text.DecimalFormatSymbols
-import java.util.{Objects, Arrays, Locale}
+import java.util.{Objects, Locale}
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ConcurrentMap
+
+import scala.collection.JavaConverters._
 
 /** Localized symbols used in date and time formatting.
   *
@@ -61,7 +63,7 @@ object DecimalStyle {
     */
   def getAvailableLocales: java.util.Set[Locale] = {
     val l: Array[Locale] = DecimalFormatSymbols.getAvailableLocales
-    new java.util.HashSet[Locale](Arrays.asList(l: _*))
+    new java.util.HashSet[Locale](l.toSet.asJava)
   }
 
   /** Obtains symbols for the default locale.

--- a/shared/src/test/scala/org/threeten/bp/format/TestDecimalStyle.scala
+++ b/shared/src/test/scala/org/threeten/bp/format/TestDecimalStyle.scala
@@ -31,14 +31,13 @@
  */
 package org.threeten.bp.format
 
-import org.scalatest.testng.TestNGSuite
-import org.testng.Assert.assertEquals
 import java.util.Locale
-import java.util.Set
-import org.testng.annotations.Test
+
+import org.junit.Test
+import org.junit.Assert._
 
 /** Test DecimalStyle. */
-@Test class TestDecimalStyle extends TestNGSuite {
+class TestDecimalStyle {
   @Test def test_getAvailableLocales(): Unit = {
     val locales: java.util.Set[Locale] = DecimalStyle.getAvailableLocales
     assertEquals(locales.size > 0, true)


### PR DESCRIPTION
I'm sending this PR to discuss how to get `threetenbp` running in `scala.js`, filling some missing bits and adapting the tests. This PR is exploratory, it shouldn't be merged yet.

It includes
* Use a snapshot of the port of java locales: [scalajs-locales](https://github.com/cquiroz/scalajs-locales). For now, the `scalajs-locales` just supports  the `Locale` and `DecimalFormatSymbols` classes, and loading of data from CLDR.
* Convert `TestDecimalStyle` to junit
* Update the build to run the js tests using junit

Some important notes

- `TestDecimalStyle` was moved from `jvm/src/test` to `shared/src/test` to make it run in both environments JVM/JS
- For some reason I cannot access some `jUnit` functions that you can with the setup used in `scalajs-java-time` or `scalajs-locales`, in particular I get a linking error calling a function `assertEquals` where the arguments are primitives. I tried all kind of ways to get it to work, the dependencies are the same comparing projects, but still it breaks. So I replaced the `assertEquals` calls with `assertTrue(...)`, far from ideal
- I disabled the coverage tasks on travis, apparently they are not supported in scala.js
- `scalajs-locales` is still a work in progress, hence the snapshot, in the near future it should support the rest needed for `threetenbp`

Any comments are welcome. Do you think the project could be converted to be more like the `scalajs-java-time` project?