### PR TITLE
Fixes broken TestDateTimeFormatters on scala 2.12.0

### DIFF
--- a/jvm/src/test/scala/org/threeten/bp/format/TestDateTimeFormatters.scala
+++ b/jvm/src/test/scala/org/threeten/bp/format/TestDateTimeFormatters.scala
@@ -112,7 +112,13 @@ object TestDateTimeFormatters {
     def isSupported(field: TemporalField): Boolean = fields.containsKey(field)
 
     def getLong(field: TemporalField): Long =
-      try fields.get(field)
+      try {
+        val result: java.lang.Long = fields.get(field)
+        if (result == null) { // This changed on scala 2.12.0 it is likely a regression on the implicit Long conversion
+          throw new NullPointerException()
+        }
+        result
+      }
       catch {
         case ex: NullPointerException =>
           throw new DateTimeException("Field missing: " + field)


### PR DESCRIPTION
After some investigation I traced the problem to the code below. Apparently this is a regression change in scala 2.12 and will be reported

In the meanwhile this fixes the bug breaking the test

Fixes #47 